### PR TITLE
feat(#53): lambda duckdb thread support

### DIFF
--- a/stac_fastapi/indexed/stac_fastapi/indexed/db.py
+++ b/stac_fastapi/indexed/stac_fastapi/indexed/db.py
@@ -1,19 +1,19 @@
+import os
 from logging import Logger, getLogger
-from time import time
-from typing import Any, Final, List, Optional
+from typing import Final, cast
 
 from duckdb import DuckDBPyConnection
 from duckdb import connect as duckdb_connect
+from fastapi import FastAPI
 
 from stac_fastapi.indexed.settings import get_settings
+from stac_fastapi.indexed.util import utc_now
 from stac_index.common import index_reader_classes
 
 _logger: Final[Logger] = getLogger(__file__)
-_query_timing_precision: Final[int] = 3
-_root_db_connection: DuckDBPyConnection = None
 
 
-async def connect_to_db() -> None:
+async def connect_to_db(app: FastAPI) -> None:
     index_source_uri = get_settings().parquet_index_source_uri
     compatible_index_readers = [
         index_reader
@@ -24,81 +24,61 @@ async def connect_to_db() -> None:
         raise Exception(f"no index readers support source URI '{index_source_uri}'")
     index_source = compatible_index_readers[0](index_source_uri)
     times = {}
-    start = time()
-    global _root_db_connection
-    _root_db_connection = duckdb_connect()
-    times["create db connection"] = time()
-    for config_command in index_source.get_duckdb_configuration_statements():
-        execute(
-            config_command[0],
-            config_command[1] if len(config_command) > 1 else None,
-        )
-    times["index source configuration"] = time()
-    execute("INSTALL spatial")
-    execute("LOAD spatial")
-    times["load spatial extension"] = time()
-    execute("INSTALL httpfs")
-    execute("LOAD httpfs")
-    times["load httpfs extension"] = time()
-    parquet_uris = await index_source.get_parquet_uris()
-    if len(parquet_uris.keys()) == 0:
-        raise Exception(f"no URIs found at '{index_source_uri}'")
-    for view_name, source_uri in parquet_uris.items():
-        execute(f"CREATE VIEW {view_name} AS SELECT * FROM '{source_uri}'")
-    times["create views from parquet"] = time()
+    start = utc_now()
+    duckdb_connection = duckdb_connect()
+    index_source.configure_duckdb(duckdb_connection)
+    times["create db connection"] = utc_now()
+    duckdb_connection.execute("INSTALL spatial")
+    duckdb_connection.execute("LOAD spatial")
+    times["load spatial extension"] = utc_now()
+    duckdb_connection.execute("INSTALL httpfs")
+    duckdb_connection.execute("LOAD httpfs")
+    times["load httpfs extension"] = utc_now()
+    duckdb_thread_count = os.environ.get("DUCKDB_THREADS", None)
+    lambda_memory_size = os.environ.get("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", None)
+    if duckdb_thread_count:
+        try:
+            duckdb_thread_count = int(duckdb_connection)
+            duckdb_max_memory = (
+                duckdb_thread_count * 125
+            )  # duckdb suggest 125mb per thread
+            if lambda_memory_size:
+                lambda_memory_size = int(lambda_memory_size)
+                if lambda_memory_size < duckdb_max_memory:
+                    memory_error_message = f"MemoryError: duckdb {duckdb_thread_count} threads requires:\
+                     '{duckdb_max_memory}MB'. Lambda memory: '{lambda_memory_size}MB'"
+                    _logger.error(memory_error_message)
+                    raise MemoryError(memory_error_message)
+            duckdb_connection.execute(f"SET memory_limit = '{duckdb_max_memory}MB'")
+            duckdb_connection.execute(f"SET threads to {duckdb_thread_count}")
+        except ValueError:
+            value_error_message = f"ValueError: invalid literal for duckdb thread count: '{duckdb_thread_count}'"
+            _logger.error(value_error_message)
+            raise ValueError(value_error_message)
+        except Exception as e:
+            _logger.error(e)
+            raise e
+    parquet_urls = await index_source.get_parquet_uris()
+    if len(parquet_urls.keys()) == 0:
+        raise Exception(f"no URLs found at '{index_source_uri}'")
+    for view_name, source_uri in parquet_urls.items():
+        command = f"CREATE VIEW {view_name} AS SELECT * FROM '{source_uri}'"
+        _logger.debug(command)
+        duckdb_connection.execute(command)
+    times["create views from parquet"] = utc_now()
     for operation, completed_at in times.items():
-        _logger.info(
-            "'{}' completed in {}s".format(
-                operation, round(completed_at - start, _query_timing_precision)
+        _logger.debug(
+            "'{}' completed in {}ms".format(
+                operation, (completed_at - start).microseconds / 1000
             )
         )
         start = completed_at
+    app.state.db_connection = duckdb_connection
 
 
-async def disconnect_from_db() -> None:
-    if _root_db_connection is not None:
+async def disconnect_from_db(app: FastAPI) -> None:
+    if hasattr(app.state, "db_connection") and app.state.db_connection is not None:
         try:
-            _root_db_connection.close()
+            cast(DuckDBPyConnection, app.state.db_connection).close()
         except Exception as e:
             _logger.error(e)
-
-
-def get_db_connection():
-    return _root_db_connection.cursor()
-
-
-def execute(statement: str, params: Optional[List[Any]] = None) -> None:
-    start = time()
-    get_db_connection().execute(statement, params)
-    _sql_log_message(statement, time() - start, None, params)
-
-
-def fetchone(statement: str, params: Optional[List[Any]] = None) -> Any:
-    start = time()
-    result = get_db_connection().execute(statement, params).fetchone()
-    _sql_log_message(statement, time() - start, 1 if result is not None else 0, params)
-    return result
-
-
-def fetchall(statement: str, params: Optional[List[Any]] = None) -> List[Any]:
-    start = time()
-    result = get_db_connection().execute(statement, params).fetchall()
-    _sql_log_message(statement, time() - start, len(result), params)
-    return result
-
-
-def _sql_log_message(
-    statement: str,
-    duration: float,
-    result_size: Optional[int] = None,
-    params: Optional[List[Any]] = None,
-) -> None:
-    # None of the queries logged by this API are expected to contain sensitive data
-    _logger.debug(
-        "SQL: {statement}; Params: {params}; in {time_info}s{result_info}".format(
-            statement=statement,
-            params=params,
-            time_info=round(duration, _query_timing_precision),
-            result_info="" if result_size is None else f" {result_size} row(s)",
-        )
-    )


### PR DESCRIPTION
This pull request adds support for setting multiple threads for duckdb on AWS lambda.

This can be configured with duckdb if the `DUCKDB_THREADS ` environment variable is set. If this variable is not set then duckdb configuration will occur with its default settings.

The duckdb docs suggest allocating 125MB per thread so for 8 threads this would require 1GB of available memory.

If deployed to AWS lambda the code will check for the reserved lambda environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` – The amount of memory available to the lambda function in MB which is described [here](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html).

If this lambda-specific environment variable is set, the code will test if the lamba function has enough memory to support the provided number of duckdb threads.
