### PR TITLE
53 additional

### DIFF
--- a/stac_fastapi/indexed/stac_fastapi/indexed/db.py
+++ b/stac_fastapi/indexed/stac_fastapi/indexed/db.py
@@ -124,5 +124,4 @@ def _set_duckdb_threads(duckdb_thread_count: int) -> None:
                     lambda_memory_mb,
                 )
             )
-    execute(f"SET memory_limit = '{duckdb_required_memory_mb}MB'")
     execute(f"SET threads to {duckdb_thread_count}")


### PR DESCRIPTION
Closes #53 

Avoids artificially limiting the DuckDB memory if more is available, is satisfied as long as the lambda memory configuration can support the minimum required memory.