### PR TITLE
Collect single error with append

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -36,7 +36,7 @@ SHELL ["/bin/sh", "-exc"]
 ENV PATH=/opt/app/bin:$PATH
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libgeos3.11.1 \
+    libgeos3.13.1 \
     && rm -rf /var/lib/apt/lists/*
 
 STOPSIGNAL SIGINT

--- a/packages/stac-index/src/stac_index/indexer/stac_catalog_reader.py
+++ b/packages/stac-index/src/stac_index/indexer/stac_catalog_reader.py
@@ -201,7 +201,7 @@ class StacCatalogReader:
                 except StacParserException as e:
                     item_errors.extend(e.indexing_errors)
                 except Exception as e:
-                    item_errors.extend(
+                    item_errors.append(
                         new_error(
                             type=IndexingErrorType.item_fetching,
                             description=str(e),


### PR DESCRIPTION
Change error list to use append instead of extend when adding single error.

Closes https://github.com/sparkgeo/stac-fastapi-indexed/issues/192