### PR TITLE
[#194]: Support offset in Search requests

### DIFF
--- a/packages/stac-index/src/stac_index/io/writers/source_writer.py
+++ b/packages/stac-index/src/stac_index/io/writers/source_writer.py
@@ -5,7 +5,6 @@ from stac_index.io.source import Source
 
 
 class SourceWriter(Source):
-
     @abstractmethod
     async def put_file_to_uri(self: Self, file_path: str, uri: str) -> None:
         pass

--- a/src/stac_fastapi/indexed/app.py
+++ b/src/stac_fastapi/indexed/app.py
@@ -24,6 +24,7 @@ from stac_index.indexer.types.indexing_error import IndexingError
 from stac_fastapi.indexed.core import CoreCrudClient
 from stac_fastapi.indexed.db import connect_to_db, disconnect_from_db
 from stac_fastapi.indexed.errors import get_all_errors
+from stac_fastapi.indexed.extensions.offset_pagination import OffsetPaginationExtension
 from stac_fastapi.indexed.middleware.request_log_middleware import RequestLogMiddleware
 from stac_fastapi.indexed.search.filter.filter_client import FiltersClient
 from stac_fastapi.indexed.search.search_get_request import SearchGetRequest
@@ -35,6 +36,7 @@ _logger: Final[Logger] = getLogger(__name__)
 extensions_map = {
     "sort": SortExtension(),
     "pagination": TokenPaginationExtension(),
+    "offset-pagination": OffsetPaginationExtension(),
     "filter": FilterExtension(client=FiltersClient()),
 }
 

--- a/src/stac_fastapi/indexed/core.py
+++ b/src/stac_fastapi/indexed/core.py
@@ -182,7 +182,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
             "bbox": bbox,
             "datetime": datetime,
             "limit": limit,
-             "offset": offset,
+            "offset": offset,
             "token": token,
         }
         if sortby:

--- a/src/stac_fastapi/indexed/core.py
+++ b/src/stac_fastapi/indexed/core.py
@@ -166,6 +166,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
         bbox: Optional[BBox] = None,
         datetime: Optional[str] = None,
         limit: Optional[int] = None,
+        offset: Optional[int] = None,
         query: Optional[str] = None,
         token: Optional[str] = None,
         fields: Optional[List[str]] = None,
@@ -181,6 +182,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
             "bbox": bbox,
             "datetime": datetime,
             "limit": limit,
+             "offset": offset,
             "token": token,
         }
         if sortby:

--- a/src/stac_fastapi/indexed/extensions/__init__.py
+++ b/src/stac_fastapi/indexed/extensions/__init__.py
@@ -1,2 +1,1 @@
 """Custom extensions for the indexed STAC API implementation."""
-

--- a/src/stac_fastapi/indexed/extensions/__init__.py
+++ b/src/stac_fastapi/indexed/extensions/__init__.py
@@ -1,0 +1,2 @@
+"""Custom extensions for the indexed STAC API implementation."""
+

--- a/src/stac_fastapi/indexed/extensions/offset_pagination.py
+++ b/src/stac_fastapi/indexed/extensions/offset_pagination.py
@@ -5,10 +5,9 @@ from typing import Optional
 import attr
 from fastapi import Query
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated
-
 from stac_fastapi.extensions.core.pagination.pagination import PaginationExtension
 from stac_fastapi.types.search import APIRequest
+from typing_extensions import Annotated
 
 _offset_description = (
     "Zero-based offset for result set (must be a non-negative integer)."
@@ -25,12 +24,10 @@ OffsetQuery = Annotated[
 
 @attr.s
 class GETOffsetPagination(APIRequest):
-
     offset: OffsetQuery = attr.ib(default=None)
 
 
 class POSTOffsetPagination(BaseModel):
-
     offset: Optional[int] = Field(
         default=None,
         ge=0,
@@ -40,6 +37,5 @@ class POSTOffsetPagination(BaseModel):
 
 @attr.s
 class OffsetPaginationExtension(PaginationExtension):
-
     GET = GETOffsetPagination
     POST = POSTOffsetPagination

--- a/src/stac_fastapi/indexed/extensions/offset_pagination.py
+++ b/src/stac_fastapi/indexed/extensions/offset_pagination.py
@@ -1,0 +1,45 @@
+"""Offset pagination extension wiring for search request models."""
+
+from typing import Optional
+
+import attr
+from fastapi import Query
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
+
+from stac_fastapi.extensions.core.pagination.pagination import PaginationExtension
+from stac_fastapi.types.search import APIRequest
+
+_offset_description = (
+    "Zero-based offset for result set (must be a non-negative integer)."
+)
+
+OffsetQuery = Annotated[
+    Optional[int],
+    Query(
+        ge=0,
+        description=_offset_description,
+    ),
+]
+
+
+@attr.s
+class GETOffsetPagination(APIRequest):
+
+    offset: OffsetQuery = attr.ib(default=None)
+
+
+class POSTOffsetPagination(BaseModel):
+
+    offset: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description=_offset_description,
+    )
+
+
+@attr.s
+class OffsetPaginationExtension(PaginationExtension):
+
+    GET = GETOffsetPagination
+    POST = POSTOffsetPagination

--- a/src/stac_fastapi/indexed/search/query_info.py
+++ b/src/stac_fastapi/indexed/search/query_info.py
@@ -38,11 +38,10 @@ class QueryInfo:
         # Assume logic of validating that a "previous" link is required (i.e. there is currently a non-None offset) is applied elsewhere.
         # Technically we could apply that logic here, but we cannot determine if a "next" link is required in this module, so that would be insconsistent.
         current_offset = cast(int, self.offset)
+        previous_offset = current_offset - self.limit
         return replace(
             self,
-            offset=(current_offset - self.limit)
-            if current_offset > self.limit
-            else None,
+            offset=previous_offset if previous_offset > 0 else None,
         )
 
     def to_dict(self) -> Dict[str, Any]:

--- a/src/stac_fastapi/indexed/search/search_handler.py
+++ b/src/stac_fastapi/indexed/search/search_handler.py
@@ -134,7 +134,7 @@ class SearchHandler:
                 detail="STAC data recently changed and paging behaviour cannot be guaranteed. Remove the paging token to start again.",
             )
         has_next_page = len(rows) > query_info.limit
-        has_previous_page = query_info.offset is not None
+        has_previous_page = query_info.offset is not None and query_info.offset > 0
 
         async def get_each_item(uri: str) -> Optional[Dict[str, Any]]:
             try:
@@ -218,9 +218,13 @@ class SearchHandler:
             limit=cast(
                 int, self.search_request.limit
             ),  # will have default value if not provided by caller
-            offset=None,
+            offset=self._get_offset_from_request(),
             last_load_id=get_last_load_id(),
         )
+
+    def _get_offset_from_request(self) -> Optional[int]:
+        offset_value = cast(Optional[int], getattr(self.search_request, "offset", None))
+        return offset_value
 
     async def _determine_order(
         self, sortby: Optional[List[SortExtension]] = None

--- a/tests/test_search_handler.py
+++ b/tests/test_search_handler.py
@@ -77,6 +77,57 @@ async def test_search_multi_item_success(
 @pytest.mark.asyncio
 @mock.patch("stac_fastapi.indexed.search.search_handler.format_query_object_name")
 @mock.patch("stac_fastapi.indexed.search.search_handler.get_last_load_id")
+@mock.patch("stac_fastapi.indexed.search.search_handler.get_token_link")
+@mock.patch("stac_fastapi.indexed.search.search_handler.get_search_link")
+@mock.patch("stac_fastapi.indexed.search.search_handler.get_catalog_link")
+@mock.patch("stac_fastapi.indexed.search.search_handler.StacParser")
+@mock.patch("stac_fastapi.indexed.search.search_handler.get_sortable_configs_by_field")
+@mock.patch("stac_fastapi.indexed.search.search_handler.fix_item_links")
+@mock.patch("stac_fastapi.indexed.search.search_handler.fetch_dict")
+@mock.patch("stac_fastapi.indexed.search.search_handler.fetchall")
+async def test_search_applies_offset(
+    fetchall_mock: mock.AsyncMock,
+    fetch_dict_mock: mock.AsyncMock,
+    fix_item_links_mock: mock.MagicMock,
+    get_sortable_configs_by_field_mock: mock.MagicMock,
+    stac_parser_mock: mock.MagicMock,
+    get_catalog_link_mock: mock.MagicMock,
+    get_search_link_mock: mock.MagicMock,
+    get_token_link_mock: mock.MagicMock,
+    get_last_load_id_mock: mock.MagicMock,
+    format_query_object_name_mock: mock.MagicMock,
+) -> None:
+    from stac_fastapi.indexed.search.search_handler import SearchHandler
+
+    fetchall_mock.return_value = []
+    get_sortable_configs_by_field_mock.return_value = {
+        "collection": SimpleNamespace(items_column="col1"),
+        "id": SimpleNamespace(items_column="col2"),
+    }
+    stac_parser_mock.side_effect = []
+    get_last_load_id_mock.return_value = "test-load-id"
+    await SearchHandler(
+        search_request=SimpleNamespace(
+            token=None,
+            ids=None,
+            collections=None,
+            bbox=None,
+            intersects=None,
+            datetime=None,
+            filter=None,
+            filter_lang="cql2-json",
+            sortby=None,
+            limit=10,
+            offset=5,
+        ),
+        request=SimpleNamespace(method="POST"),
+    ).search()
+    assert fetchall_mock.await_args.args[1][-1] == 5
+
+
+@pytest.mark.asyncio
+@mock.patch("stac_fastapi.indexed.search.search_handler.format_query_object_name")
+@mock.patch("stac_fastapi.indexed.search.search_handler.get_last_load_id")
 @mock.patch("stac_fastapi.indexed.search.search_handler.get_search_link")
 @mock.patch("stac_fastapi.indexed.search.search_handler.get_catalog_link")
 @mock.patch("stac_fastapi.indexed.search.search_handler.StacParser")

--- a/tests/test_search_handler.py
+++ b/tests/test_search_handler.py
@@ -122,7 +122,9 @@ async def test_search_applies_offset(
         ),
         request=SimpleNamespace(method="POST"),
     ).search()
-    assert fetchall_mock.await_args.args[1][-1] == 5
+    await_call = fetchall_mock.await_args
+    assert await_call is not None
+    assert await_call.args[1][-1] == 5
 
 
 @pytest.mark.asyncio

--- a/tests/with_environment/integration_tests/test_get_search.py
+++ b/tests/with_environment/integration_tests/test_get_search.py
@@ -181,6 +181,21 @@ def test_get_search_limit() -> None:
     assert len(get_link_dict_by_rel(search_result, "next")) == 1
 
 
+def test_get_search_offset() -> None:
+    limit = 1
+    offset = 1
+    assert len(_all_items) > offset + limit
+    search_result = requests.get(
+        f"{api_base_url}/search", params={"limit": limit, "offset": offset}
+    ).json()
+    assert len(search_result["features"]) == limit
+    assert search_result["features"][0]["id"] == _all_items[offset]["id"]
+    assert len(get_link_dict_by_rel(search_result, "previous")) == 1
+    next_href = get_link_dict_by_rel(search_result, "next")[0]["href"]
+    next_result = requests.get(next_href).json()
+    assert next_result["features"][0]["id"] == _all_items[offset + limit]["id"]
+
+
 def test_get_search_token() -> None:
     limit = 1
     assert len(_all_items) > limit

--- a/tests/with_environment/integration_tests/test_post_search.py
+++ b/tests/with_environment/integration_tests/test_post_search.py
@@ -174,6 +174,31 @@ def test_post_search_limit() -> None:
     assert len(get_link_dict_by_rel(search_result, "next")) == 1
 
 
+def test_post_search_offset() -> None:
+    limit = 1
+    offset = 1
+    assert len(_all_items) > offset + limit
+    search_result = requests.post(
+        f"{api_base_url}/search", json={"limit": limit, "offset": offset}
+    ).json()
+    assert len(search_result["features"]) == limit
+    assert search_result["features"][0]["id"] == _all_items[offset]["id"]
+    assert len(get_link_dict_by_rel(search_result, "previous")) == 1
+    next_body = get_link_dict_by_rel(search_result, "next")[0]["body"]
+    next_result = requests.post(f"{api_base_url}/search", json=next_body).json()
+    assert next_result["features"][0]["id"] == _all_items[offset + limit]["id"]
+
+
+def test_post_search_offset_exceeds_total() -> None:
+    offset = len(_all_items) + 5
+    search_result = requests.post(
+        f"{api_base_url}/search", json={"offset": offset}
+    ).json()
+    assert len(search_result["features"]) == 0
+    assert len(get_link_dict_by_rel(search_result, "next")) == 0
+    assert len(get_link_dict_by_rel(search_result, "previous")) == 1
+
+
 def test_post_search_token() -> None:
     limit = 1
     assert len(_all_items) > limit


### PR DESCRIPTION
- Added `OffsetPaginationExtension` that exposes validated GET/POST parameters so OpenAPI advertises offset and callers get consistent validation
- Offset handling is achieved through request handling and paging state: `GET` handler now accepts the query argument and the `POST` model persists it. `SearchHandler` seeds `QueryInfo` with the caller-specified offsets and only returns “previous” links when the offset is greater than 0.